### PR TITLE
Add link to assets in sidebar, expand information slightly.

### DIFF
--- a/src/assets/index.md
+++ b/src/assets/index.md
@@ -1,5 +1,7 @@
 # Cadasta Styles & Assets
 
+In an effort to simplify branding across Cadasta applications, commonly used assets are placed in the AWS S3 Bucket titled `assets.cadasta.org`. They are then available at `https://s3.amazonaws.com/assets.cadasta.org/<FILENAME>`.
+
 ## Images
 
 ### Logos

--- a/src/toc.md
+++ b/src/toc.md
@@ -1,9 +1,7 @@
 # Summary
 
-* [Introduction](index.md)
-* [Documentation](documentation/index.md)
-  * [Gitbook Editor - Getting Started](/documentation/gitbook-editor-getting-started.md)
-* [Glossary](glossary.md)
-
-
-
+- [Introduction](index.md)
+- [Documentation](documentation/index.md)
+  - [Gitbook Editor - Getting Started](/documentation/gitbook-editor-getting-started.md)
+- [Styles & Assets](assets/index.md)
+- [Glossary](glossary.md)


### PR DESCRIPTION
I noticed the assets page isn't appearing in the sidebar.  This should resolve that. Additionally, I've added a quick line about where assets should live.