### PR TITLE
Fix deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
     - stage: deploy gitbook
       if: branch = master AND type = push
       script:
-        - npm install --only=dev --ignore-scripts
+        - npm install --ignore-scripts
         - npm run docs:build
       deploy:
         provider: pages


### PR DESCRIPTION
When I merged #6, the [subsequent deployment failed](https://travis-ci.org/Cadasta/cadasta-internal-docs/builds/515579239). It looks like not all required dependencies are installed. 

I was able to reproduce the issue locally. Removing the `--only=dev` flag fixes the problem locally. I was able to successfully build the project using the same commands from `.travis.yml`. 